### PR TITLE
Fix for An assert statement has a side-effect

### DIFF
--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -72,8 +72,10 @@ class TestMap():
 
     def test_delete(self, pmap):
         """Tests deleting a user from the PasswordMap."""
-        assert pmap.delete(REALM, USER) is True
-        assert pmap.delete(REALM, USER) is False
+        deleted = pmap.delete(REALM, USER)
+        assert deleted is True
+        deleted_again = pmap.delete(REALM, USER)
+        assert deleted_again is False
 
     def test_find(self, pmap):
         """Tests finding a user's digest in the PasswordMap."""


### PR DESCRIPTION
To fix this, move side-effecting method calls out of `assert` expressions and assert on their returned values afterward.

Best fix for this file:
- In `tests/test_digest.py`, inside `TestMap.test_delete`, replace:
  - `assert pmap.delete(REALM, USER) is True`
  - `assert pmap.delete(REALM, USER) is False`
- with:
  - `deleted = pmap.delete(REALM, USER)` then `assert deleted is True`
  - `deleted_again = pmap.delete(REALM, USER)` then `assert deleted_again is False`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._